### PR TITLE
Refine Justyna dash steering for fixed distance

### DIFF
--- a/src/enemies/justyna.js
+++ b/src/enemies/justyna.js
@@ -106,9 +106,14 @@
       const nx = clamp(e.x + e.dash.ux * move, 0, W);
       const ny = clamp(e.y + e.dash.uy * move, 0, H);
       const actual = Math.hypot(nx - e.x, ny - e.y);
-      e.x = nx; e.y = ny;
-      e.dash.remain = Math.max(0, e.dash.remain - actual);
+      e.x = nx;
+      e.y = ny;
       e.facing = (e.dash.ux >= 0) ? 1 : -1;
+      if (actual <= 0.0001) {
+        e.dash = null;
+        return;
+      }
+      e.dash.remain = Math.max(0, e.dash.remain - actual);
       if (e.dash.remain <= 0.0001) e.dash = null;
     }
 
@@ -122,6 +127,30 @@
       e.facing = (ux >= 0) ? 1 : -1;
     }
 
+    function computeDashAlignment(proj, perp, dist, len, wid){
+      const margin = wid * 0.5 + player.radius + 12;
+      const behind = proj < -0.5 * M;
+      const farAhead = proj > len + 0.6 * M;
+      const lateral = Math.abs(perp) > margin;
+      const tooFar = dist > len + E_DIST * 0.6;
+
+      let targetProjMin = 0.35 * M;
+      let targetProjMax = len - 0.35 * M;
+      if (targetProjMax < targetProjMin) targetProjMax = targetProjMin;
+      if (behind) targetProjMin = 0;
+      if (farAhead || tooFar) targetProjMax = len;
+      const targetProj = clamp(proj, targetProjMin, targetProjMax);
+
+      const softPerpRange = Math.min(margin * 0.6, Math.max(player.radius + 0.35 * M, wid * 0.35));
+      let targetPerp = clamp(perp, -softPerpRange, softPerpRange);
+      if (lateral) {
+        const hardLimit = Math.max(softPerpRange, margin - 0.15 * M);
+        targetPerp = clamp(perp, -hardLimit, hardLimit);
+      }
+
+      return { targetProj, targetPerp, margin, behind, farAhead, lateral, tooFar };
+    }
+
     function maybeTriggerEFor(type, ang){
       if (!canUseE()) return;
       const dx = player.x - e.x;
@@ -133,16 +162,89 @@
       const ca = Math.cos(ang);
       const sa = Math.sin(ang);
       const proj = dx * ca + dy * sa;
-      const perp = Math.abs(-dx * sa + dy * ca);
-      const margin = wid * 0.5 + player.radius + 12;
-      const dashAng = Math.atan2(dy, dx);
-      if (proj < -0.5 * M) {
-        if (dist > len * 0.5) startDash(dashAng);
-        return;
+      const perp = -dx * sa + dy * ca;
+      const params = computeDashAlignment(proj, perp, dist, len, wid);
+      const shiftLocalX = proj - params.targetProj;
+      const shiftLocalY = perp - params.targetPerp;
+      const shiftDist = Math.hypot(shiftLocalX, shiftLocalY);
+
+      const triggeredByShift = shiftDist > 0.45 * M;
+      const shouldDash = params.behind || params.farAhead || params.lateral || params.tooFar || triggeredByShift;
+      if (!shouldDash) return;
+
+      const moveX = shiftLocalX * ca - shiftLocalY * sa;
+      const moveY = shiftLocalX * sa + shiftLocalY * ca;
+
+      const candidates = [];
+      if (Math.hypot(moveX, moveY) > 0.0001) candidates.push({ vx: moveX, vy: moveY });
+      candidates.push({ vx: dx, vy: dy });
+      if (params.behind || params.farAhead || triggeredByShift) {
+        candidates.push({ vx: ca, vy: sa });
       }
-      if (proj > len + 0.6 * M || perp > margin || dist > len + E_DIST * 0.6) {
-        startDash(dashAng);
+      if (params.lateral) {
+        const lateralSign = (perp >= 0) ? 1 : -1;
+        candidates.push({ vx: -sa * lateralSign, vy: ca * lateralSign });
       }
+      candidates.push({ vx: moveX * 0.7 + dx * 0.3, vy: moveY * 0.7 + dy * 0.3 });
+
+      function evaluateCandidate(vec){
+        const mag = Math.hypot(vec.vx, vec.vy);
+        if (mag <= 0.0001) return null;
+        const ux = vec.vx / mag;
+        const uy = vec.vy / mag;
+        const nx = clamp(e.x + ux * E_DIST, 0, W);
+        const ny = clamp(e.y + uy * E_DIST, 0, H);
+        const actual = Math.hypot(nx - e.x, ny - e.y);
+        if (actual <= 0.0001) return null;
+        const pdx = player.x - nx;
+        const pdy = player.y - ny;
+        const newDist = Math.hypot(pdx, pdy);
+        const newProj = pdx * ca + pdy * sa;
+        const newPerp = -pdx * sa + pdy * ca;
+        const post = computeDashAlignment(newProj, newPerp, newDist, len, wid);
+        const newShiftX = newProj - post.targetProj;
+        const newShiftY = newPerp - post.targetPerp;
+        const newShiftDist = Math.hypot(newShiftX, newShiftY);
+        const improvement = shiftDist - newShiftDist;
+        const resolvedCount =
+          (params.behind && !post.behind ? 1 : 0) +
+          (params.farAhead && !post.farAhead ? 1 : 0) +
+          (params.lateral && !post.lateral ? 1 : 0) +
+          (params.tooFar && !post.tooFar ? 1 : 0) +
+          (triggeredByShift && improvement > 0 ? 1 : 0);
+        const resolved = resolvedCount > 0;
+        const improved = improvement > 0.08 * M || (shiftDist > 0 && newShiftDist < shiftDist * 0.7) || newShiftDist < 0.32 * M;
+        if (!resolved && !improved) return null;
+        const penalty =
+          (post.behind ? 0.30 * M : 0) +
+          (post.farAhead ? 0.24 * M : 0) +
+          (post.lateral ? 0.20 * M : 0) +
+          (post.tooFar ? 0.18 * M : 0);
+        const reward = resolvedCount * 0.08 * M + Math.max(0, improvement) * 0.1;
+        const score = newShiftDist + penalty - reward;
+        return {
+          angle: Math.atan2(uy, ux),
+          newShiftDist,
+          improvement,
+          resolvedCount,
+          score,
+        };
+      }
+
+      let best = null;
+      for (const candidate of candidates) {
+        const result = evaluateCandidate(candidate);
+        if (!result) continue;
+        if (!best || result.score < best.score - 0.02 * M ||
+            (Math.abs(result.score - best.score) <= 0.02 * M &&
+             (result.newShiftDist < best.newShiftDist - 0.01 * M ||
+              (Math.abs(result.newShiftDist - best.newShiftDist) <= 0.01 * M && result.improvement > best.improvement)))) {
+          best = result;
+        }
+      }
+
+      if (!best) return;
+      startDash(best.angle);
     }
 
     function afterSkill(){


### PR DESCRIPTION
## Summary
- force Justyna's E dash to always commit to the full 2.5m travel while handling boundary stops safely
- add reusable dash alignment helper and evaluate several candidate vectors to pick smarter targets even with the fixed travel distance

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdf33adffc8332bf0f8789278d540b