### PR TITLE
Teach Justyna to respect preferred range and feint bursts

### DIFF
--- a/src/enemies/justyna.js
+++ b/src/enemies/justyna.js
@@ -21,10 +21,14 @@
     const W = cfg.bounds.w, H = cfg.bounds.h;
 
     const SPEED = 3.94 * M;
+    const PREFERRED_RANGE = 6.0 * M;
+    const RANGE_DEADZONE = 0.12 * M;
+    const FEINT_DELAY_MAX = 0.5;
 
     const W_CAST = 0.40;
     const W_RANGE = 6.5 * M;
     const W_RADIUS = 2.0 * M;
+    const W_TRIGGER_DIST = 8.5 * M;
 
     const Q1_CAST = 0.40;
     const Q1_LEN = 6.25 * M;
@@ -48,7 +52,7 @@
     const R_PULSES = 8;
     const R_RADIUS = 3.0 * M;
     const R_MAX_OFFSET = 6.0 * M;
-    const R_TRIGGER = R_MAX_OFFSET + R_RADIUS;
+    const R_TRIGGER_DIST = 9.0 * M;
     const R_SPEED_FACTOR = 0.60;
 
     const PAD = 40;
@@ -74,6 +78,7 @@
       r_active: false,
       rHits: 0,
       rTimer: 0,
+      pendingSkill: null,
     };
 
     (function spawn(){
@@ -86,17 +91,33 @@
 
     function currentSpeedFactor(){ return e.r_active ? R_SPEED_FACTOR : 1; }
 
-    function steerTowardsPlayer(dt, factor = 1){
+    function steerTowardsPreferredRange(dt, factor = 1){
       if (e.dash) return;
       const dx = player.x - e.x;
       const dy = player.y - e.y;
-      const d = Math.hypot(dx, dy) || 1;
+      const dist = Math.hypot(dx, dy);
+      const desired = PREFERRED_RANGE;
+      const delta = dist - desired;
       const speed = SPEED * factor;
-      e.x += (dx / d) * speed * dt;
-      e.y += (dy / d) * speed * dt;
+      const absDelta = Math.abs(delta);
+      if (absDelta > RANGE_DEADZONE) {
+        const direction = delta > 0 ? 1 : -1;
+        const move = Math.min(speed * dt, absDelta);
+        let ux = 0;
+        let uy = 0;
+        if (dist > 0) {
+          const inv = 1 / dist;
+          ux = dx * inv;
+          uy = dy * inv;
+        } else {
+          ux = (e.facing >= 0) ? 1 : -1;
+        }
+        const nx = clamp(e.x + ux * move * direction, 0, W);
+        const ny = clamp(e.y + uy * move * direction, 0, H);
+        e.x = nx;
+        e.y = ny;
+      }
       e.facing = (dx >= 0) ? 1 : -1;
-      e.x = clamp(e.x, 0, W);
-      e.y = clamp(e.y, 0, H);
     }
 
     function updateDash(dt){
@@ -106,9 +127,14 @@
       const nx = clamp(e.x + e.dash.ux * move, 0, W);
       const ny = clamp(e.y + e.dash.uy * move, 0, H);
       const actual = Math.hypot(nx - e.x, ny - e.y);
-      e.x = nx; e.y = ny;
-      e.dash.remain = Math.max(0, e.dash.remain - actual);
+      e.x = nx;
+      e.y = ny;
       e.facing = (e.dash.ux >= 0) ? 1 : -1;
+      if (actual <= 0.0001) {
+        e.dash = null;
+        return;
+      }
+      e.dash.remain = Math.max(0, e.dash.remain - actual);
       if (e.dash.remain <= 0.0001) e.dash = null;
     }
 
@@ -122,6 +148,30 @@
       e.facing = (ux >= 0) ? 1 : -1;
     }
 
+    function computeDashAlignment(proj, perp, dist, len, wid){
+      const margin = wid * 0.5 + player.radius + 12;
+      const behind = proj < -0.5 * M;
+      const farAhead = proj > len + 0.6 * M;
+      const lateral = Math.abs(perp) > margin;
+      const tooFar = dist > len + E_DIST * 0.6;
+
+      let targetProjMin = 0.35 * M;
+      let targetProjMax = len - 0.35 * M;
+      if (targetProjMax < targetProjMin) targetProjMax = targetProjMin;
+      if (behind) targetProjMin = 0;
+      if (farAhead || tooFar) targetProjMax = len;
+      const targetProj = clamp(proj, targetProjMin, targetProjMax);
+
+      const softPerpRange = Math.min(margin * 0.6, Math.max(player.radius + 0.35 * M, wid * 0.35));
+      let targetPerp = clamp(perp, -softPerpRange, softPerpRange);
+      if (lateral) {
+        const hardLimit = Math.max(softPerpRange, margin - 0.15 * M);
+        targetPerp = clamp(perp, -hardLimit, hardLimit);
+      }
+
+      return { targetProj, targetPerp, margin, behind, farAhead, lateral, tooFar };
+    }
+
     function maybeTriggerEFor(type, ang){
       if (!canUseE()) return;
       const dx = player.x - e.x;
@@ -133,16 +183,89 @@
       const ca = Math.cos(ang);
       const sa = Math.sin(ang);
       const proj = dx * ca + dy * sa;
-      const perp = Math.abs(-dx * sa + dy * ca);
-      const margin = wid * 0.5 + player.radius + 12;
-      const dashAng = Math.atan2(dy, dx);
-      if (proj < -0.5 * M) {
-        if (dist > len * 0.5) startDash(dashAng);
-        return;
+      const perp = -dx * sa + dy * ca;
+      const params = computeDashAlignment(proj, perp, dist, len, wid);
+      const shiftLocalX = proj - params.targetProj;
+      const shiftLocalY = perp - params.targetPerp;
+      const shiftDist = Math.hypot(shiftLocalX, shiftLocalY);
+
+      const triggeredByShift = shiftDist > 0.45 * M;
+      const shouldDash = params.behind || params.farAhead || params.lateral || params.tooFar || triggeredByShift;
+      if (!shouldDash) return;
+
+      const moveX = shiftLocalX * ca - shiftLocalY * sa;
+      const moveY = shiftLocalX * sa + shiftLocalY * ca;
+
+      const candidates = [];
+      if (Math.hypot(moveX, moveY) > 0.0001) candidates.push({ vx: moveX, vy: moveY });
+      candidates.push({ vx: dx, vy: dy });
+      if (params.behind || params.farAhead || triggeredByShift) {
+        candidates.push({ vx: ca, vy: sa });
       }
-      if (proj > len + 0.6 * M || perp > margin || dist > len + E_DIST * 0.6) {
-        startDash(dashAng);
+      if (params.lateral) {
+        const lateralSign = (perp >= 0) ? 1 : -1;
+        candidates.push({ vx: -sa * lateralSign, vy: ca * lateralSign });
       }
+      candidates.push({ vx: moveX * 0.7 + dx * 0.3, vy: moveY * 0.7 + dy * 0.3 });
+
+      function evaluateCandidate(vec){
+        const mag = Math.hypot(vec.vx, vec.vy);
+        if (mag <= 0.0001) return null;
+        const ux = vec.vx / mag;
+        const uy = vec.vy / mag;
+        const nx = clamp(e.x + ux * E_DIST, 0, W);
+        const ny = clamp(e.y + uy * E_DIST, 0, H);
+        const actual = Math.hypot(nx - e.x, ny - e.y);
+        if (actual <= 0.0001) return null;
+        const pdx = player.x - nx;
+        const pdy = player.y - ny;
+        const newDist = Math.hypot(pdx, pdy);
+        const newProj = pdx * ca + pdy * sa;
+        const newPerp = -pdx * sa + pdy * ca;
+        const post = computeDashAlignment(newProj, newPerp, newDist, len, wid);
+        const newShiftX = newProj - post.targetProj;
+        const newShiftY = newPerp - post.targetPerp;
+        const newShiftDist = Math.hypot(newShiftX, newShiftY);
+        const improvement = shiftDist - newShiftDist;
+        const resolvedCount =
+          (params.behind && !post.behind ? 1 : 0) +
+          (params.farAhead && !post.farAhead ? 1 : 0) +
+          (params.lateral && !post.lateral ? 1 : 0) +
+          (params.tooFar && !post.tooFar ? 1 : 0) +
+          (triggeredByShift && improvement > 0 ? 1 : 0);
+        const resolved = resolvedCount > 0;
+        const improved = improvement > 0.08 * M || (shiftDist > 0 && newShiftDist < shiftDist * 0.7) || newShiftDist < 0.32 * M;
+        if (!resolved && !improved) return null;
+        const penalty =
+          (post.behind ? 0.30 * M : 0) +
+          (post.farAhead ? 0.24 * M : 0) +
+          (post.lateral ? 0.20 * M : 0) +
+          (post.tooFar ? 0.18 * M : 0);
+        const reward = resolvedCount * 0.08 * M + Math.max(0, improvement) * 0.1;
+        const score = newShiftDist + penalty - reward;
+        return {
+          angle: Math.atan2(uy, ux),
+          newShiftDist,
+          improvement,
+          resolvedCount,
+          score,
+        };
+      }
+
+      let best = null;
+      for (const candidate of candidates) {
+        const result = evaluateCandidate(candidate);
+        if (!result) continue;
+        if (!best || result.score < best.score - 0.02 * M ||
+            (Math.abs(result.score - best.score) <= 0.02 * M &&
+             (result.newShiftDist < best.newShiftDist - 0.01 * M ||
+              (Math.abs(result.newShiftDist - best.newShiftDist) <= 0.01 * M && result.improvement > best.improvement)))) {
+          best = result;
+        }
+      }
+
+      if (!best) return;
+      startDash(best.angle);
     }
 
     function afterSkill(){
@@ -153,6 +276,7 @@
       }
       e.state = 'move';
       e.t = 0;
+      e.pendingSkill = null;
     }
 
     function applyRectHit(len, wid, ang){
@@ -233,6 +357,38 @@
       e.rTimer = R_DELAY;
     }
 
+    function queueSkillWithFeint(type){
+      const delay = Math.random() * FEINT_DELAY_MAX;
+      if (delay <= 0) {
+        if (type === 'W') startW();
+        else if (type === 'R') startR();
+        return;
+      }
+      e.pendingSkill = { type, timer: delay };
+    }
+
+    function updatePendingSkill(dt){
+      if (!e.pendingSkill) return;
+      if (e.queue[0] !== e.pendingSkill.type) {
+        e.pendingSkill = null;
+        return;
+      }
+      e.pendingSkill.timer -= dt;
+      if (e.pendingSkill.timer > 0) return;
+      const type = e.pendingSkill.type;
+      const dx = player.x - e.x;
+      const dy = player.y - e.y;
+      const dist = Math.hypot(dx, dy);
+      const inRange = (type === 'W') ? (dist <= W_TRIGGER_DIST) : (dist <= R_TRIGGER_DIST);
+      if (!inRange) {
+        e.pendingSkill = null;
+        return;
+      }
+      e.pendingSkill = null;
+      if (type === 'W') startW();
+      else if (type === 'R') startR();
+    }
+
     function applyRHit(){
       if (e.rTele) {
         const cx = clamp(e.rTele.x, 0, W);
@@ -281,6 +437,7 @@
       e.q2Window = Math.max(0, e.q2Window - dt);
       updateDash(dt);
       purgeTelegraphs(dt);
+      updatePendingSkill(dt);
 
       switch (e.state) {
         case 'spawn_idle': {
@@ -299,26 +456,30 @@
           } else if (next === 'Q2' && e.q2Lock <= 0 && e.q2Window > 0) {
             maybeTriggerEFor('Q2', Math.atan2(dy, dx));
           }
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           if (next === 'W') {
-            if (dist <= W_RANGE + 15) startW();
+            if (!e.pendingSkill && dist <= W_TRIGGER_DIST) {
+              queueSkillWithFeint('W');
+            }
           } else if (next === 'Q1') {
             if (dist <= Q1_TRIG) startQ1();
           } else if (next === 'Q2') {
             if (e.q2Lock <= 0 && e.q2Window > 0 && dist <= Q2_TRIG) startQ2();
           } else if (next === 'R') {
-            if (dist <= R_TRIGGER) startR();
+            if (!e.pendingSkill && dist <= R_TRIGGER_DIST) {
+              queueSkillWithFeint('R');
+            }
           }
           break;
         }
         case 'W_cast': {
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           if (e.t >= W_CAST) { applyW(); }
           break;
         }
         case 'Q1_cast1': {
           if (e.qRect) maybeTriggerEFor('Q1', e.qRect.ang);
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           if (e.t >= Q1_CAST) {
             e.t = 0;
             applyRectHit(Q1_LEN, Q1_WIDTH, e.qAng);
@@ -328,7 +489,7 @@
         }
         case 'Q1_cast2': {
           if (e.qRect) maybeTriggerEFor('Q1', e.qRect.ang);
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           if (e.t >= Q1_CAST) {
             applyRectHit(Q1_LEN, Q1_WIDTH, e.qAng);
             finishQ1();
@@ -337,7 +498,7 @@
         }
         case 'Q2_cast': {
           if (e.qRect) maybeTriggerEFor('Q2', e.qRect.ang);
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           if (e.t >= Q2_CAST) {
             applyRectHit(Q2_LEN, Q2_WIDTH, e.qAng);
             finishQ2();
@@ -345,7 +506,7 @@
           break;
         }
         case 'R_cast': {
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           if (e.t >= R_CAST) {
             e.state = 'R_channel';
             e.t = 0;
@@ -353,7 +514,7 @@
           break;
         }
         case 'R_channel': {
-          steerTowardsPlayer(dt, currentSpeedFactor());
+          steerTowardsPreferredRange(dt, currentSpeedFactor());
           e.rTimer -= dt;
           if (e.rTimer <= 0 && e.rHits > 0) {
             applyRHit();


### PR DESCRIPTION
## Summary
- steer Justyna toward a preferred 6 m spacing instead of always rushing the player
- gate W and R so they trigger at 8.5 m / 9.0 m and introduce 0–0.5 s feint delays before casting
- add a pending-skill queue to re-check range before firing delayed W or R casts

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cdf33adffc8332bf0f8789278d540b