### PR TITLE
Adjust Justyna R caution damage pacing

### DIFF
--- a/docs/ENEMIES.md
+++ b/docs/ENEMIES.md
@@ -182,4 +182,4 @@ Notes
 - Cast: 0.5s; chooses an offset within 6.0m toward the player; circle radius 3.0m forms there
 - Channel: Fires pulses every 0.125s for 8 total hits; the area follows Justyna as she moves
 - Restrictions: While channeling R she moves at 60% speed and other skills are disabled
-- Mitigation: Every two successful hits refund 1 Caution (never dropping below 0) to offset the unusually long channel; if the follow-up pulse never lands before the channel ends, the refund is skipped
+- Mitigation: Each pulse chips 0.25 from the player's Caution life (3 total), letting the full channel build up to a lethal threat without requiring paired hits

--- a/docs/ENEMIES_SUMMARY.md
+++ b/docs/ENEMIES_SUMMARY.md
@@ -64,7 +64,7 @@
 - W: Cast 0.4s; Caution circle radius 2.0m at a point up to 6.5m away (anchored in world)
 - Q1: Two Caution sweeps; each cast 0.4s for a rectangle 6.25m x 1.8m that follows her position while the angle is locked; unlocks Q2 for 3.0s but Q2 stays locked for 0.4s after Q1 completes; skipped if the window expires
 - Q2: Cast 0.7s; Caution rectangle 7.0m x 1.5m, only usable inside the Q1 window
-- R: Cast 0.5s then 8 Caution pulses every 0.125s in a circle radius 3.0m offset up to 6.0m; area follows her and movement is at 60% with other skills disabled; every two successful hits refund 1 Caution (floored at 0) to soften the sustained damage—refunds only apply if both pulses actually land
+- R: Cast 0.5s then 8 Caution pulses every 0.125s in a circle radius 3.0m offset up to 6.0m; area follows her and movement is at 60% with other skills disabled; each pulse removes 0.25 from the player's 3-point Caution life, so the full channel becomes lethal without requiring paired hits
 
 Notes
 - Colors: Danger = red, Caution = yellow (both telegraph and projectiles follow this)

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -5,7 +5,7 @@ Version: v0.4.1
 
 Current Focus (2025-09-20)
 - Debugging Justyna: all skill hits are marked as Caution (yellow) and telegraphs use caution colors until testing is done. Remember to revert to Danger values once QA is satisfied.
-- Balance tweak: Justyna R now refunds 1 Caution after every two successful pulses; `makeJustyna()` owns this via the new `onJustynaRHit` / `onJustynaRChannelEnd` callbacks.
+- Balance tweak: Justyna R now chips away the Caution life (3 total) by 0.25 per pulse; `makeJustyna()` owns this via the `onJustynaRHit` callback.
 - Key files for this debug pass: index.html (options checkbox), src/main.js (makeJustyna wiring), src/enemies/justyna.js (skill logic), docs/ENEMIES*.md (documented spec).
 - Per user request: always update this HANDOFF.md so future sessions can sync by reading it (they will be told simply "HANDOFF.mdを見て").
 
@@ -74,7 +74,7 @@ Haze (current spec highlights)
 
 Notes
 - Enemy Options: `ENEMY_OPTIONS` 配列（src/main.js）がスポーン候補とUIトグルを一元管理。全解除ボタンもここを参照するため、Justynaのような追加敵も自動で対象になる。全OFF時のフォールバック（Hisui〜Vanya）は `fallback: true` で区別。
-- Justyna's R pulses call `onJustynaRHit({ skill: 'R', enemy: 'Justyna', pulse, pulsesRemaining })` and notify `onJustynaRChannelEnd` on exit so the host can refund 1 Caution every two hits while still killing the player if no follow-up pulse lands.
+- Justyna's R pulses call `onJustynaRHit({ skill: 'R', enemy: 'Justyna', pulse, pulsesRemaining })` (0.25 Caution damage per pulse) and notify `onJustynaRChannelEnd` on exit.
 - Images used: touka_tia.png, hisui_touka_55px.png, abigail.png, Luku.png, Katja.png, darko.png, Vanya.png, Debi.png, Marlene.png.
 - New images: Haze.png（Haze）。
 

--- a/src/main.js
+++ b/src/main.js
@@ -196,57 +196,18 @@ function makeHaze() {
 }
 
 function makeJustyna() {
-  let rCautionBuffer = 0;
-  let rPendingKO = false;
-
-  const resetJustynaR = () => {
-    rCautionBuffer = 0;
-    rPendingKO = false;
-  };
-
-  const cautionHit = () => {
-    if (ignoreCautionSelected()) {
-      resetJustynaR();
-      return false;
-    }
-    state.cautionHits += 1;
-    resetJustynaR();
+  const applyCautionDamage = amount => {
+    if (ignoreCautionSelected()) return false;
+    state.cautionHits = Math.min(3, state.cautionHits + amount);
     if (state.cautionHits >= 3) gameOver();
     return true;
   };
 
-  const handleJustynaRHit = () => {
-    if (ignoreCautionSelected()) {
-      resetJustynaR();
-      return false;
-    }
-    state.cautionHits += 1;
-    rCautionBuffer += 1;
-    if (rCautionBuffer >= 2) {
-      rCautionBuffer -= 2;
-      state.cautionHits = Math.max(0, state.cautionHits - 1);
-      rPendingKO = false;
-    } else if (state.cautionHits >= 3) {
-      rPendingKO = true;
-    }
-    if (state.cautionHits >= 3 && !rPendingKO) {
-      gameOver();
-      resetJustynaR();
-    }
-    return true;
-  };
+  const cautionHit = () => applyCautionDamage(1);
 
-  const handleJustynaRChannelEnd = () => {
-    if (ignoreCautionSelected()) {
-      resetJustynaR();
-      return;
-    }
-    if (rPendingKO && state.cautionHits >= 3) {
-      rPendingKO = false;
-      gameOver();
-    }
-    resetJustynaR();
-  };
+  const handleJustynaRHit = () => applyCautionDamage(0.25);
+
+  const handleJustynaRChannelEnd = () => {};
 
   return Enemies.Justyna({
     METER,


### PR DESCRIPTION
## Summary
- apply a shared caution-damage helper so Justyna's R pulses chip 0.25 life each time
- document the new R damage cadence across the handoff and enemy reference files

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cec3f128048332bcbeede26a5b7180